### PR TITLE
fix(setup): correct symlink path for .mcp.json

### DIFF
--- a/scripts/set-up.sh
+++ b/scripts/set-up.sh
@@ -278,7 +278,7 @@ setup_mcp() {
     echo "  - Self mode: mcp config already exists, skipping"
     return
   fi
-  link_if_missing "../${OKITE_ROOT_REL}/.mcp.json" "${ROOT_DIR}/.mcp.json" ".mcp.json"
+  link_if_missing "${OKITE_ROOT_REL}/.mcp.json" "${ROOT_DIR}/.mcp.json" ".mcp.json"
 }
 
 setup_cursor() {


### PR DESCRIPTION
## Summary

- `setup_mcp` 関数が作成する `.mcp.json` のシンボリックリンクのソースパスが誤っていた
- `.mcp.json` は `ROOT_DIR` 直下に配置されるため、リンク元は `${OKITE_ROOT_REL}/.mcp.json`（`ROOT_DIR` からの相対パス）が正しい
- 誤って `../${OKITE_ROOT_REL}/.mcp.json` としていたため、1階層上を参照してしまい壊れたシンボリックリンクが作成されていた

## Root Cause

`link_if_missing` の第1引数（シンボリックリンクのリンク先）は、リンクファイルが置かれる場所からの相対パスとして解釈される。

- リンクファイル: `ROOT_DIR/.mcp.json`
- リンク先の正しいパス: `references/okite-ai/.mcp.json`（= `${OKITE_ROOT_REL}/.mcp.json`）
- 誤ったパス: `../references/okite-ai/.mcp.json`（= `../${OKITE_ROOT_REL}/.mcp.json`）

他の `link_if_missing` 呼び出し（`.claude/settings.json` 等）は `ROOT_DIR/.claude/` 配下に置かれるため `../` が必要だが、`.mcp.json` はルート直下なので不要。

## Test plan

- [x] `references/okite-ai/scripts/set-up.sh` を実行する
- [x] `ROOT_DIR/.mcp.json` が `references/okite-ai/.mcp.json` を正しく参照するシンボリックリンクになっていることを確認
- [x] `.mcp.json` の内容が読めることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)