### PR TITLE
fix: generate-agents-md.sh の出力先をプロジェクトルートにする

### DIFF
--- a/scripts/generate-agents-md.sh
+++ b/scripts/generate-agents-md.sh
@@ -5,9 +5,12 @@ set -e
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 OKITE_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
 
-COMMON_MD="${OKITE_ROOT}/COMMON.md"
-RULES_DIR="${OKITE_ROOT}/.agent/rules"
-OUTPUT_FILE="${OKITE_ROOT}/AGENTS.md"
+# 第1引数でプロジェクトルートを指定可能（未指定時はOKITE_ROOT）
+TARGET_ROOT="${1:-${OKITE_ROOT}}"
+
+COMMON_MD="${TARGET_ROOT}/COMMON.md"
+RULES_DIR="${TARGET_ROOT}/.agent/rules"
+OUTPUT_FILE="${TARGET_ROOT}/AGENTS.md"
 
 echo "Generating AGENTS.md..."
 echo "  COMMON_MD: ${COMMON_MD}"

--- a/scripts/set-up.sh
+++ b/scripts/set-up.sh
@@ -391,7 +391,7 @@ done
 echo "======================================"
 echo "Generating AGENTS.md..."
 echo "======================================"
-bash "${OKITE_SCRIPT_DIR}/generate-agents-md.sh"
+bash "${OKITE_SCRIPT_DIR}/generate-agents-md.sh" "${ROOT_DIR}"
 
 echo "======================================"
 echo "Setup completed successfully!"


### PR DESCRIPTION
generate-agents-md.sh が常に OKITE_ROOT (references/okite-ai/) に AGENTS.md を出力していた問題を修正。

- generate-agents-md.sh: 第1引数でターゲットルートを指定可能に
- set-up.sh: generate-agents-md.sh に ROOT_DIR を渡すように変更

シンボリックリンク経由で引数なしで呼んだ場合も $0 から
正しくプロジェクトルートが解決される。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small shell-script change that only alters where `AGENTS.md` is written and which `COMMON.md`/rules directory are read; main risk is generating output in an unexpected location if the wrong root is passed.
> 
> **Overview**
> Fixes `generate-agents-md.sh` to accept an optional target project root (defaults to `OKITE_ROOT`) and to read/write `COMMON.md`, `.agent/rules`, and `AGENTS.md` under that root.
> 
> Updates `set-up.sh` to pass `ROOT_DIR` when generating `AGENTS.md`, so setup writes the file into the consuming project rather than the okite-ai repo.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65a0110f3d303159221f50ee0fd00a6fb7e7eb2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->