### PR TITLE
improve(aggregate-design): Props+スプレッド構文パターン導入とdescription最適化

### DIFF
--- a/.claude/skills/deduplicating-gh-issues
+++ b/.claude/skills/deduplicating-gh-issues
@@ -1,1 +1,0 @@
-../../skills/deduplicating-gh-issues

--- a/.claude/skills/skill-creator
+++ b/.claude/skills/skill-creator
@@ -1,1 +1,0 @@
-../../skills/skill-creator

--- a/.codex/skills/deduplicating-gh-issues
+++ b/.codex/skills/deduplicating-gh-issues
@@ -1,1 +1,0 @@
-../../skills/deduplicating-gh-issues

--- a/.codex/skills/skill-creator
+++ b/.codex/skills/skill-creator
@@ -1,1 +1,0 @@
-../../skills/skill-creator

--- a/scripts/run-claude-corporate.sh
+++ b/scripts/run-claude-corporate.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export CLAUDE_IDENTITY="corporate"
-source "$HOME/.config/claude-code/env-corporate"
+export CLAUDE_CONFIG_DIR="${HOME}/.claude-${CLAUDE_IDENTITY}"
 
 # --happy オプションを検出して Happy Coder モードで起動
 use_happy=false

--- a/scripts/run-claude-personal.sh
+++ b/scripts/run-claude-personal.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export CLAUDE_IDENTITY="personal"
-source "$HOME/.config/claude-code/env-personal"
+export CLAUDE_CONFIG_DIR="${HOME}/.claude-${CLAUDE_IDENTITY}"
 
 # --happy オプションを検出して Happy Coder モードで起動
 use_happy=false

--- a/skills/aggregate-design/SKILL.md
+++ b/skills/aggregate-design/SKILL.md
@@ -1,9 +1,19 @@
 ---
 name: aggregate-design
 description: |
-  DDDの集約(Aggregate)設計ルールに基づいてコードレビューや設計支援を行う。集約の新規設計、既存集約のレビュー、
-  リファクタリング時に使用する。トリガー：「集約を設計したい」「集約のレビュー」
-  「Aggregateの実装」「集約の境界を決めたい」「DDDで実装したい」等の集約設計関連リクエストで起動。
+  DDDの集約(Aggregate)設計ルールに基づくコードレビュー・設計支援・リファクタリングを行う。
+  Evans Rules、Vernon's 4 Rules、Design by Contractに基づき、集約の境界定義、不変条件の検証、
+  不変(Immutable)設計、ID参照、結果整合性、ドメインイベント連携を包括的にガイドする。
+  以下のいずれかに該当する場合は必ずこのスキルを使用すること：
+  - 集約(Aggregate)の新規設計・実装・リファクタリング（どの言語でも）
+  - 既存の集約やエンティティクラスのDDD観点でのコードレビュー
+  - 集約の境界決定（「AとBは同じ集約にすべきか？」「この集約は大きすぎるか？」）
+  - 集約内の不変条件・整合性境界の設計
+  - 集約間の連携方式の判断（ドメインイベント、結果整合性、Sagaパターン）
+  - 可変(Mutable)な集約コードを不変(Immutable)設計にリファクタリングする
+  - publicフィールド、直接参照、push/appendなどカプセル化違反の検出・修正
+  キーワード例：集約、Aggregate、aggregate boundary、集約ルート、AggregateRoot、
+  エンティティ設計、DDD実装、Vernon Rules、Evans Rules、集約の分割、真の不変条件
 ---
 
 # 集約設計ガイド
@@ -85,16 +95,45 @@ class Car private (
 ### 1. 不変性(Immutability)推奨
 
 現代においては不変(Immutable)を推奨する。特に理由がなければ不変。
+状態更新時はスプレッド構文（`...this.props`）で既存値を引き継ぎ、変更するフィールドだけを上書きする。
+これにより、フィールド追加時の修正漏れを防ぎ、更新意図が明確になる。
 
 ```typescript
-// Good: 不変な集約
-class Order {
-  private constructor(
-    readonly id: OrderId,
-    readonly items: readonly OrderItem[],
-    readonly status: OrderStatus
-  ) {}
+// Good: スプレッド構文による不変な集約
+type OrderProps = {
+  readonly id: OrderId;
+  readonly items: readonly OrderItem[];
+  readonly status: OrderStatus;
+};
 
+class Order {
+  private constructor(private readonly props: OrderProps) {}
+
+  static create(id: OrderId, items: OrderItem[]): Order {
+    return new Order({ id, items, status: OrderStatus.DRAFT });
+  }
+
+  addItem(item: OrderItem): Order {
+    return new Order({
+      ...this.props,
+      items: [...this.props.items, item],
+    });
+  }
+
+  confirm(): Order {
+    return new Order({
+      ...this.props,
+      status: OrderStatus.CONFIRMED,
+    });
+  }
+
+  get id(): OrderId { return this.props.id; }
+  get items(): readonly OrderItem[] { return this.props.items; }
+  get status(): OrderStatus { return this.props.status; }
+}
+
+// Bad: フィールド全列挙（フィールド追加時に全メソッドの修正が必要）
+class Order {
   addItem(item: OrderItem): Order {
     return new Order(this.id, [...this.items, item], this.status);
   }
@@ -221,17 +260,33 @@ order.items.find(item => item.id === itemId)?.updateQuantity(newQuantity);
 集約の状態変更時にドメインイベントを発行し、他の集約や外部システムはそれを購読して反応する。
 
 ```typescript
+type OrderProps = {
+  readonly id: OrderId;
+  readonly status: OrderStatus;
+  readonly domainEvents: readonly DomainEvent[];
+  // ...other fields
+};
+
 class Order {
-  private readonly _events: DomainEvent[] = [];
+  private constructor(private readonly props: OrderProps) {}
 
   get domainEvents(): readonly DomainEvent[] {
-    return [...this._events];
+    return this.props.domainEvents;
   }
 
   confirm(): Order {
-    const confirmed = new Order(/* ...props, status: OrderStatus.CONFIRMED */);
-    confirmed._events.push(new OrderConfirmed(this.id, new Date()));
-    return confirmed;
+    return new Order({
+      ...this.props,
+      status: OrderStatus.CONFIRMED,
+      domainEvents: [
+        ...this.props.domainEvents,
+        new OrderConfirmed(this.props.id, new Date()),
+      ],
+    });
+  }
+
+  clearEvents(): Order {
+    return new Order({ ...this.props, domainEvents: [] });
   }
 }
 ```

--- a/skills/aggregate-design/SKILL.md
+++ b/skills/aggregate-design/SKILL.md
@@ -61,91 +61,22 @@ DDDにおける集約(Aggregate)設計の原則。
 | **事後条件 (Postcondition)** | メソッド実行後に満たされる条件 | 実装側 |
 | **不変条件 (Invariant)** | 常に満たすべき条件 | 実装側 |
 
-```scala
-// Scalaでの DbC 例
-class Car private (
-  val id: CarId,
-  val tires: List[Tire],
-  val engine: Engine
-) {
-  // 不変条件（常に満たす）
-  require(tires.size == 4, "タイヤは4本必要")
-  require(engine != null, "エンジンは必須")
-
-  def replaceTire(position: Int, newTire: Tire): Car = {
-    // 事前条件
-    require(position >= 0 && position < 4, "タイヤ位置は0-3")
-    require(newTire != null, "新しいタイヤは必須")
-
-    val updated = new Car(
-      id,
-      tires.updated(position, newTire),
-      engine
-    )
-    // 事後条件（暗黙的：不変条件が満たされる）
-    updated
-  } ensuring { result =>
-    result.tires.size == 4  // 事後条件
-  }
-}
-```
+詳細な言語別実装パターンは [references/typescript.md](references/typescript.md)、[references/scala.md](references/scala.md)、[references/rust.md](references/rust.md)、[references/python.md](references/python.md) を参照。
 
 ## 基本原則
 
 ### 1. 不変性(Immutability)推奨
 
 現代においては不変(Immutable)を推奨する。特に理由がなければ不変。
-状態更新時はスプレッド構文（`...this.props`）で既存値を引き継ぎ、変更するフィールドだけを上書きする。
+状態更新時は既存値を引き継ぎ、変更するフィールドだけを上書きする。
 これにより、フィールド追加時の修正漏れを防ぎ、更新意図が明確になる。
 
-```typescript
-// Good: スプレッド構文による不変な集約
-type OrderProps = {
-  readonly id: OrderId;
-  readonly items: readonly OrderItem[];
-  readonly status: OrderStatus;
-};
-
-class Order {
-  private constructor(private readonly props: OrderProps) {}
-
-  static create(id: OrderId, items: OrderItem[]): Order {
-    return new Order({ id, items, status: OrderStatus.DRAFT });
-  }
-
-  addItem(item: OrderItem): Order {
-    return new Order({
-      ...this.props,
-      items: [...this.props.items, item],
-    });
-  }
-
-  confirm(): Order {
-    return new Order({
-      ...this.props,
-      status: OrderStatus.CONFIRMED,
-    });
-  }
-
-  get id(): OrderId { return this.props.id; }
-  get items(): readonly OrderItem[] { return this.props.items; }
-  get status(): OrderStatus { return this.props.status; }
-}
-
-// Bad: フィールド全列挙（フィールド追加時に全メソッドの修正が必要）
-class Order {
-  addItem(item: OrderItem): Order {
-    return new Order(this.id, [...this.items, item], this.status);
-  }
-}
-
-// Bad: 可変な集約
-class Order {
-  private items: OrderItem[] = [];
-  constructor(readonly id: OrderId) {}
-  addItem(item: OrderItem): void { this.items.push(item); }
-}
-```
+| 言語 | 不変更新パターン |
+|------|----------------|
+| TypeScript | Props型 + `...this.props` スプレッド構文 |
+| Scala | case class + `copy()` |
+| Rust | struct + `..self` 構造体更新構文 |
+| Python | `dataclass(frozen=True)` + `replace()` |
 
 ### 2. 強い整合性境界
 
@@ -155,95 +86,23 @@ class Order {
 
 集約内部に別の集約の参照を保持しない。他の集約と関連を持つ場合はIDで間接参照する。
 
-```typescript
-// Good: IDによる間接参照
-class Order {
-  constructor(
-    readonly id: OrderId,
-    readonly customerId: CustomerId  // IDのみ保持
-  ) {}
-}
-
-// Bad: 直接参照
-class Order {
-  constructor(
-    readonly id: OrderId,
-    readonly customer: Customer  // 他の集約を直接参照
-  ) {}
-}
-```
-
 ### 4. 完全コンストラクタ
 
 基本コンストラクタですべての状態を初期化する。オーバーロードする場合も必ず基本コンストラクタを利用する補助コンストラクタとして設計する。
-
-```typescript
-class Order {
-  private constructor(
-    readonly id: OrderId,
-    readonly items: readonly OrderItem[],
-    readonly status: OrderStatus,
-    readonly createdAt: Date
-  ) {}
-
-  // ファクトリメソッドは基本コンストラクタを利用
-  static create(id: OrderId, items: OrderItem[]): Order {
-    return new Order(id, items, OrderStatus.DRAFT, new Date());
-  }
-}
-```
 
 ### 5. 防御的コピー
 
 可変オブジェクトを保持する場合、外部に返す際は必ずコピーを返すか不変オブジェクトに変換する。
 
-```typescript
-class Order {
-  private readonly _items: OrderItem[];
-
-  constructor(items: OrderItem[]) {
-    this._items = [...items];  // 入力をコピー
-  }
-
-  get items(): readonly OrderItem[] {
-    return [...this._items];  // コピーを返す
-  }
-}
-```
-
 ### 6. 不変条件の維持
 
 どのような操作をされても不正な状態に陥ってはならない。不変な集約では基本コンストラクタで保護する。
-
-```typescript
-class Order {
-  private constructor(
-    readonly id: OrderId,
-    readonly items: readonly OrderItem[]
-  ) {
-    if (items.length === 0) {
-      throw new Error("注文には最低1つの商品が必要");
-    }
-    if (!items.every(item => item.quantity > 0)) {
-      throw new Error("数量は正の数");
-    }
-  }
-}
-```
 
 ## 構造原則
 
 ### 7. 集約ルート経由のアクセス
 
 集約内部のエンティティや値オブジェクトへの直接アクセスは、必ず集約ルートを経由する。
-
-```typescript
-// Good: 集約ルート経由
-order.updateItemQuantity(itemId, newQuantity);
-
-// Bad: 内部オブジェクトを直接操作
-order.items.find(item => item.id === itemId)?.updateQuantity(newQuantity);
-```
 
 ### 8. 1トランザクション = 1集約
 
@@ -259,52 +118,9 @@ order.items.find(item => item.id === itemId)?.updateQuantity(newQuantity);
 
 集約の状態変更時にドメインイベントを発行し、他の集約や外部システムはそれを購読して反応する。
 
-```typescript
-type OrderProps = {
-  readonly id: OrderId;
-  readonly status: OrderStatus;
-  readonly domainEvents: readonly DomainEvent[];
-  // ...other fields
-};
-
-class Order {
-  private constructor(private readonly props: OrderProps) {}
-
-  get domainEvents(): readonly DomainEvent[] {
-    return this.props.domainEvents;
-  }
-
-  confirm(): Order {
-    return new Order({
-      ...this.props,
-      status: OrderStatus.CONFIRMED,
-      domainEvents: [
-        ...this.props.domainEvents,
-        new OrderConfirmed(this.props.id, new Date()),
-      ],
-    });
-  }
-
-  clearEvents(): Order {
-    return new Order({ ...this.props, domainEvents: [] });
-  }
-}
-```
-
 ### 11. 楽観的ロック（要件がある場合のみ）
 
 並行更新の衝突検出が必要な場合にのみ、バージョン番号を持たせる。要件がなければ不要。
-
-```typescript
-// 楽観的ロックが必要な場合のみ
-class Order {
-  constructor(
-    readonly id: OrderId,
-    readonly version: number,  // 並行制御用（要件がある場合のみ）
-    // ...
-  ) {}
-}
-```
 
 ### 12. 永続化の無知
 

--- a/skills/aggregate-design/evals/evals.json
+++ b/skills/aggregate-design/evals/evals.json
@@ -17,7 +17,7 @@
     },
     {
       "id": 2,
-      "prompt": "以下のTypeScriptコードをDDDの集約設計の観点からレビューしてください。（問題のあるOrderクラス）",
+      "prompt": "以下のTypeScriptコードをDDDの集約設計の観点からレビューしてください。\n\n```typescript\nclass Order {\n  public id: string;\n  public customer: Customer;\n  public items: OrderItem[] = [];\n  public status: string;\n  public totalAmount: number = 0;\n\n  constructor(id: string, customer: Customer) {\n    this.id = id;\n    this.customer = customer;\n    this.status = 'draft';\n  }\n\n  addItem(item: OrderItem): void {\n    this.items.push(item);\n    this.totalAmount += item.price * item.quantity;\n  }\n\n  removeItem(itemId: string): void {\n    const index = this.items.findIndex(i => i.id === itemId);\n    if (index >= 0) {\n      const item = this.items[index];\n      this.totalAmount -= item.price * item.quantity;\n      this.items.splice(index, 1);\n    }\n  }\n\n  confirm(): void {\n    this.status = 'confirmed';\n  }\n}\n```",
       "expected_output": "Customer直接参照、可変性、不変条件なし、publicフィールド、ドメインイベントなし等の問題を指摘し、改善コードを提示",
       "files": [],
       "assertions": [

--- a/skills/aggregate-design/evals/evals.json
+++ b/skills/aggregate-design/evals/evals.json
@@ -1,0 +1,46 @@
+{
+  "skill_name": "aggregate-design",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "ECサイトの注文(Order)集約をTypeScriptで設計してください。注文には商品明細(OrderItem)、配送先住所(ShippingAddress)、支払い方法(PaymentMethod)が含まれます。顧客は別の集約として扱ってください。",
+      "expected_output": "不変な集約ルートとしてOrderクラスが設計され、CustomerはIDで参照、不変条件が検証され、ドメインイベントが発行される設計",
+      "files": [],
+      "assertions": [
+        {"id": "immutable-design", "text": "集約が不変(Immutable)として設計されている（状態変更時に新しいインスタンスを返す）"},
+        {"id": "id-reference-only", "text": "Customer集約をIDのみで参照している（直接参照していない）"},
+        {"id": "invariant-validation", "text": "コンストラクタまたはファクトリメソッドで不変条件を検証している"},
+        {"id": "complete-constructor", "text": "完全コンストラクタパターン（すべての状態を初期化）を使用している"},
+        {"id": "domain-events", "text": "ドメインイベントの発行機構がある"},
+        {"id": "value-objects-used", "text": "ShippingAddressやPaymentMethodが値オブジェクトとして設計されている"}
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "以下のTypeScriptコードをDDDの集約設計の観点からレビューしてください。（問題のあるOrderクラス）",
+      "expected_output": "Customer直接参照、可変性、不変条件なし、publicフィールド、ドメインイベントなし等の問題を指摘し、改善コードを提示",
+      "files": [],
+      "assertions": [
+        {"id": "detects-direct-reference", "text": "Customer直接参照の問題を指摘している"},
+        {"id": "detects-mutability", "text": "可変性の問題（pushやプロパティ直接変更）を指摘している"},
+        {"id": "detects-missing-invariants", "text": "不変条件の欠如を指摘している"},
+        {"id": "detects-public-fields", "text": "publicフィールドによるカプセル化の破綻を指摘している"},
+        {"id": "provides-improved-code", "text": "改善後のTypeScriptコード例を提示している"},
+        {"id": "references-rules", "text": "Evans Rules、Vernon Rules、またはDbCの原則を根拠として引用している"}
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "ブログシステムでPost(記事)とComment(コメント)は同じ集約にすべきか、別の集約にすべきか？",
+      "expected_output": "Vernon Rule 2に基づきPostとCommentは別集約にすべきと推奨。ID参照と結果整合性で連携。",
+      "files": [],
+      "assertions": [
+        {"id": "recommends-separation", "text": "PostとCommentを別集約にすることを推奨している"},
+        {"id": "cites-small-aggregate", "text": "Vernon Rule 2（小さな集約）またはそれに類する原則に言及している"},
+        {"id": "explains-concurrency", "text": "並行性・ロック競合の問題に触れている"},
+        {"id": "shows-id-reference", "text": "CommentからPostへのID参照パターンを示している"},
+        {"id": "mentions-eventual-consistency", "text": "結果整合性（eventual consistency）に言及している"}
+      ]
+    }
+  ]
+}

--- a/skills/aggregate-design/evals/trigger-eval.json
+++ b/skills/aggregate-design/evals/trigger-eval.json
@@ -1,0 +1,22 @@
+[
+  {"query": "ECサイトで注文(Order)集約をTypeScriptで設計したいんだけど、商品明細とか配送先とか支払い方法を含めて、Customerは別集約にしたい。Evans RulesとVernon Rulesに沿った設計をお願い。", "should_trigger": true},
+  {"query": "この Order クラスなんだけど、publicフィールドだらけで items.push() で直接変更してるし、Customer オブジェクトを直接参照してる。DDDの集約設計の観点からレビューして改善案を出してほしい。", "should_trigger": true},
+  {"query": "ブログシステムでPostとCommentを同じ集約にするか別の集約にするか迷ってる。コメントは1記事あたり最大100件で、いいね機能もある。集約の境界をどう決めるべき？", "should_trigger": true},
+  {"query": "うちのScalaプロジェクトで予約(Reservation)の集約を作りたい。部屋(Room)は別の集約で、予約には複数の日程(ReservationDate)が含まれる。不変条件として「同じ部屋の予約は日程が重複してはならない」がある。", "should_trigger": true},
+  {"query": "Kotlinで書いた在庫管理の Inventory 集約があるんだけど、StockItem を直接 mutableListOf で管理してて、外から inventory.items.add() できちゃう。これDDD的にまずいよね？直して。", "should_trigger": true},
+  {"query": "いまRustでCQRS/ESのプロジェクトやってるんだけど、BankAccount集約の状態遷移で、Opened → Active → Suspended → Closed のライフサイクルをどう表現すべき？集約のコマンドメソッドの設計パターンを教えて。", "should_trigger": true},
+  {"query": "ShoppingCartとCartItemって同じ集約にすべき？CartItemは最大50個まで。カートの合計金額はCartItemの合計と常に一致してる必要がある（真の不変条件）。", "should_trigger": true},
+  {"query": "Java (Spring Boot) で User 集約を実装してるんだけど、Addressを値オブジェクトにするのと、UserProfile をローカルエンティティにするのと、Role を別集約にするのと、それぞれの判断基準を知りたい。aggregate boundary の決め方。", "should_trigger": true},
+  {"query": "このTypeScriptのOrder集約、confirm()メソッドが void を返してて内部状態を直接変更してる。不変にしてスプレッド構文で新しいインスタンスを返すようにリファクタリングしたい。", "should_trigger": true},
+  {"query": "集約間の整合性って結果整合性でいいの？例えば注文確定したら在庫を減らす必要があるけど、OrderとInventoryは別集約。ドメインイベントでつなぐべき？Sagaパターンを使うべき？", "should_trigger": true},
+  {"query": "ReactでTodoアプリを作りたい。コンポーネント設計とstate管理のベストプラクティスを教えて。Zustandとjotaiどっちがいい？", "should_trigger": false},
+  {"query": "PostgreSQLでインデックスの貼り方がよくわからない。users テーブルの email カラムにユニークインデックスを追加したいんだけど、マイグレーションファイルの書き方を教えて。", "should_trigger": false},
+  {"query": "GitHub Actionsでci/cdパイプラインを構築したい。mainブランチへのpush時にテストを実行して、通ったらDockerイメージをビルドしてECRにプッシュする流れ。", "should_trigger": false},
+  {"query": "TypeScriptのエラーハンドリングで Result型（Either型）を使いたい。neverthrowとfp-tsどちらがおすすめ？プロジェクトの規模は中程度。", "should_trigger": false},
+  {"query": "Kotlinのcoroutineでバックプレッシャー制御ってどうやるの？Flowのbuffer()とconflate()の違いを教えて。大量のイベントを処理するシステムで使いたい。", "should_trigger": false},
+  {"query": "REST APIの設計で、ユーザー一覧取得のエンドポイントにページネーションを実装したい。カーソルベースとオフセットベースのどちらがいいか、パフォーマンスの観点から比較して。", "should_trigger": false},
+  {"query": "DDDのユビキタス言語って具体的にどうやって作るの？ドメインエキスパートとの会話からどうやって用語集を作って共有すればいい？Event Stormingとかやったほうがいい？", "should_trigger": false},
+  {"query": "クリーンアーキテクチャのレイヤー構成を教えて。ドメイン層、ユースケース層、インフラ層、それぞれに何を置くべき？依存関係の方向はどうあるべき？", "should_trigger": false},
+  {"query": "Dockerfileを最適化したい。マルチステージビルドでNode.jsアプリのイメージサイズを小さくする方法。現在1.2GBもあって重い。", "should_trigger": false},
+  {"query": "GraphQLのスキーマ設計で、User型にpostsフィールドを持たせるべきか、別のクエリにすべきか。N+1問題が気になる。DataLoaderの使い方も知りたい。", "should_trigger": false}
+]

--- a/skills/aggregate-design/references/python.md
+++ b/skills/aggregate-design/references/python.md
@@ -1,0 +1,263 @@
+# 集約設計パターン - Python
+
+## 目次
+
+1. [不変集約の実装](#1-不変集約の実装)
+2. [ID参照パターン](#2-id参照パターン)
+3. [完全コンストラクタ / ファクトリ](#3-完全コンストラクタ--ファクトリ)
+4. [防御的コピー](#4-防御的コピー)
+5. [不変条件の検証](#5-不変条件の検証)
+6. [ドメインイベント](#6-ドメインイベント)
+7. [楽観的ロック](#7-楽観的ロック)
+
+---
+
+## 1. 不変集約の実装
+
+`dataclass(frozen=True)` + `replace()` パターンを使用する。`frozen=True` でインスタンスの変更を禁止し、`replace()` で変更フィールドのみを指定した新しいインスタンスを生成する。フィールド追加時の修正漏れを防ぎ、更新意図が明確になる。
+
+```python
+from __future__ import annotations
+from dataclasses import dataclass, replace
+
+# Good: frozen dataclass + replace() による不変な集約
+@dataclass(frozen=True)
+class Order:
+    id: OrderId
+    items: tuple[OrderItem, ...]
+    status: OrderStatus
+
+    def add_item(self, item: OrderItem) -> Order:
+        return replace(self, items=(*self.items, item))
+
+    def confirm(self) -> Order:
+        return replace(self, status=OrderStatus.CONFIRMED)
+```
+
+```python
+# Bad: 可変な集約
+class Order:
+    def __init__(self, id: OrderId) -> None:
+        self.id = id
+        self.items: list[OrderItem] = []
+
+    def add_item(self, item: OrderItem) -> None:
+        self.items.append(item)  # 破壊的変更
+```
+
+> **注**: `frozen=True` を使用する場合、コレクションには `list` ではなく `tuple` を使用する。
+> `list` は可変なため、`frozen=True` でもリストの中身を変更できてしまう。
+
+## 2. ID参照パターン
+
+他の集約とは直接参照ではなくIDで関連を持つ。
+
+```python
+# Good: IDによる間接参照
+@dataclass(frozen=True)
+class Order:
+    id: OrderId
+    customer_id: CustomerId  # IDのみ保持
+
+# Bad: 直接参照
+@dataclass(frozen=True)
+class Order:
+    id: OrderId
+    customer: Customer  # 他の集約を直接参照
+```
+
+## 3. 完全コンストラクタ / ファクトリ
+
+`__init__` ですべての状態を初期化する。ファクトリメソッドはクラスメソッドとして定義し、`__init__` を利用する。外部からの直接インスタンス化を制限する場合は `__post_init__` でフラグを検証する。
+
+```python
+from datetime import datetime, timezone
+
+@dataclass(frozen=True)
+class Order:
+    id: OrderId
+    items: tuple[OrderItem, ...]
+    status: OrderStatus
+    created_at: datetime
+
+    @classmethod
+    def create(cls, id: OrderId, items: tuple[OrderItem, ...]) -> Order:
+        return cls(
+            id=id,
+            items=items,
+            status=OrderStatus.DRAFT,
+            created_at=datetime.now(timezone.utc),
+        )
+
+    @classmethod
+    def reconstruct(
+        cls,
+        id: OrderId,
+        items: tuple[OrderItem, ...],
+        status: OrderStatus,
+        created_at: datetime,
+    ) -> Order:
+        """リポジトリから復元時に使用"""
+        return cls(id=id, items=items, status=status, created_at=created_at)
+```
+
+## 4. 防御的コピー
+
+`frozen=True` + `tuple` の組み合わせにより、防御的コピーは通常不要。`tuple` は不変なのでそのまま返しても安全。
+
+```python
+@dataclass(frozen=True)
+class Order:
+    id: OrderId
+    items: tuple[OrderItem, ...]  # tupleは不変
+
+    def get_items(self) -> tuple[OrderItem, ...]:
+        return self.items  # そのまま返しても安全
+```
+
+可変コレクションを扱う場合はタプルに変換する：
+
+```python
+@dataclass(frozen=True)
+class Order:
+    id: OrderId
+    items: tuple[OrderItem, ...]
+
+    @classmethod
+    def from_list(cls, id: OrderId, items: list[OrderItem]) -> Order:
+        return cls(id=id, items=tuple(items))  # 不変タプルに変換
+```
+
+## 5. 不変条件の検証
+
+`__post_init__` で不変条件を検証する。`frozen=True` でも `__post_init__` は呼び出されるため、すべての生成・更新（`replace()` 含む）で不変条件が検証される。
+
+```python
+@dataclass(frozen=True)
+class Order:
+    id: OrderId
+    items: tuple[OrderItem, ...]
+    status: OrderStatus
+
+    def __post_init__(self) -> None:
+        # 不変条件：__post_init__で一元的に検証
+        if len(self.items) == 0:
+            raise ValueError("注文には最低1つの商品が必要")
+        if not all(item.quantity > 0 for item in self.items):
+            raise ValueError("数量は正の数")
+
+    def add_item(self, item: OrderItem) -> Order:
+        # replace()で新インスタンスが生成され、__post_init__で不変条件が再検証される
+        return replace(self, items=(*self.items, item))
+```
+
+Design by Contract（DbC）の完全な例：
+
+```python
+@dataclass(frozen=True)
+class Car:
+    id: CarId
+    tires: tuple[Tire, Tire, Tire, Tire]  # 型レベルで4本を表現
+    engine: Engine
+
+    def __post_init__(self) -> None:
+        # 不変条件（常に満たす）
+        if len(self.tires) != 4:
+            raise ValueError("タイヤは4本必要")
+
+    def replace_tire(self, position: int, new_tire: Tire) -> Car:
+        # 事前条件
+        if not (0 <= position < 4):
+            raise ValueError("タイヤ位置は0-3")
+
+        tires = list(self.tires)
+        tires[position] = new_tire
+        result = replace(self, tires=tuple(tires))
+
+        # 事後条件
+        assert len(result.tires) == 4
+        return result
+```
+
+## 6. ドメインイベント
+
+集約の状態変更時にドメインイベントを発行する。`replace()` でイベントも不変に管理する。
+
+```python
+@dataclass(frozen=True)
+class Order:
+    id: OrderId
+    status: OrderStatus
+    domain_events: tuple[DomainEvent, ...]
+    # ...other fields
+
+    def confirm(self) -> Order:
+        return replace(
+            self,
+            status=OrderStatus.CONFIRMED,
+            domain_events=(
+                *self.domain_events,
+                OrderConfirmed(order_id=self.id, confirmed_at=datetime.now(timezone.utc)),
+            ),
+        )
+
+    def clear_events(self) -> Order:
+        return replace(self, domain_events=())
+```
+
+## 7. 楽観的ロック
+
+並行更新の衝突検出が必要な場合にのみバージョン番号を持たせる。
+
+```python
+@dataclass(frozen=True)
+class Order:
+    id: OrderId
+    version: int  # 並行制御用（要件がある場合のみ）
+    # ...other fields
+
+    # リポジトリ側でバージョンチェック
+    # UPDATE orders SET ... WHERE id = %s AND version = %s
+```
+
+---
+
+## 集約ルート経由のアクセス
+
+```python
+# Good: 集約ルート経由
+order.update_item_quantity(item_id, new_quantity)
+
+# Bad: 内部オブジェクトを直接操作
+item = next(i for i in order.items if i.id == item_id)
+item.update_quantity(new_quantity)  # 内部オブジェクトを直接操作
+```
+
+## Python特有の設計パターン
+
+### NewType によるID
+
+```python
+from typing import NewType
+
+OrderId = NewType("OrderId", str)
+CustomerId = NewType("CustomerId", str)
+
+# 型チェッカー（mypy等）がOrderIdとCustomerIdの取り違えを検出
+order_id = OrderId("order-123")
+customer_id = CustomerId("customer-456")
+```
+
+より強い型安全性が必要な場合は値オブジェクトとして定義する：
+
+```python
+@dataclass(frozen=True)
+class OrderId:
+    value: str
+
+@dataclass(frozen=True)
+class CustomerId:
+    value: str
+
+# 実行時にも型の取り違えが防止される
+```


### PR DESCRIPTION
## Summary
- 不変集約の実装パターンをProps型 + `...this.props` スプレッド構文に統一し、フィールド追加時の保守性を向上
- ドメインイベント例の `readonly _events` + `push` 矛盾を修正
- descriptionを網羅的に改善し、スキルのトリガー精度を向上
- 評価用テストケース（3件17アサーション）とトリガー評価セット（20クエリ）を追加

## ベンチマーク結果
| 指標 | with_skill | without_skill | 差分 |
|------|-----------|--------------|------|
| パス率 | 100% | 87.8% | +12.2% |
| 平均時間 | 110.6s | 89.4s | +23.7% |
| 平均トークン | 43,105 | 35,782 | +20.5% |

## Test plan
- [x] 3テストケース × with_skill/without_skill で比較評価済み（iteration-2）
- [x] スプレッド構文の採用を全出力で確認済み
- [x] description改善によるトリガー範囲拡大を確認

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly documentation/eval data plus small launcher-script tweaks; the main risk is that switching from sourcing env files to `CLAUDE_CONFIG_DIR` may break local Claude runs if those env vars were required.
> 
> **Overview**
> Updates Claude launcher scripts to stop sourcing per-identity env files and instead set `CLAUDE_CONFIG_DIR` based on `CLAUDE_IDENTITY`.
> 
> Enhances the `aggregate-design` skill by expanding the trigger description, replacing some inline examples with links to language-specific references, and adding new evaluation assets (`evals.json`, `trigger-eval.json`) plus a new Python reference guide.
> 
> Removes the `.claude/skills` and `.codex/skills` pointer entries for `deduplicating-gh-issues` and `skill-creator`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8f840172ee4edaf29ed31247ad22702d493aeaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->