### PR TITLE
feat(aggregate-design): add Rust, Scala, and TypeScript references fo…

### DIFF
--- a/skills/aggregate-design/references/rust.md
+++ b/skills/aggregate-design/references/rust.md
@@ -1,0 +1,318 @@
+# 集約設計パターン - Rust
+
+## 目次
+
+1. [不変集約の実装](#1-不変集約の実装)
+2. [ID参照パターン](#2-id参照パターン)
+3. [完全コンストラクタ / ファクトリ](#3-完全コンストラクタ--ファクトリ)
+4. [防御的コピー](#4-防御的コピー)
+5. [不変条件の検証](#5-不変条件の検証)
+6. [ドメインイベント](#6-ドメインイベント)
+7. [楽観的ロック](#7-楽観的ロック)
+
+---
+
+## 1. 不変集約の実装
+
+struct + `..self` 構造体更新構文パターンを使用する。Rustでは所有権システムにより安全なミューテーションが可能だが、集約設計では不変パターンも有効。
+
+```rust
+// Good: struct + 構造体更新構文による不変な集約
+#[derive(Clone)]
+pub struct Order {
+    id: OrderId,
+    items: Vec<OrderItem>,
+    status: OrderStatus,
+}
+
+impl Order {
+    pub fn add_item(self, item: OrderItem) -> Order {
+        let mut items = self.items;
+        items.push(item);
+        Order { items, ..self }
+    }
+
+    pub fn confirm(self) -> Order {
+        Order {
+            status: OrderStatus::Confirmed,
+            ..self
+        }
+    }
+
+    pub fn id(&self) -> &OrderId { &self.id }
+    pub fn items(&self) -> &[OrderItem] { &self.items }
+    pub fn status(&self) -> &OrderStatus { &self.status }
+}
+```
+
+Rustでは所有権により安全なミューテーションも可能（`&mut self`パターン）：
+
+```rust
+// Rust特有: 所有権による安全なミューテーション
+impl Order {
+    pub fn add_item(&mut self, item: OrderItem) {
+        self.items.push(item);
+    }
+
+    pub fn confirm(&mut self) {
+        self.status = OrderStatus::Confirmed;
+    }
+}
+```
+
+> **注**: Rustの所有権システムは共有ミュータビリティを型レベルで防ぐため、
+> 他の言語で不変性が推奨される理由（予期せぬ副作用の防止）が言語レベルで保証される。
+> プロジェクトの方針に応じて不変パターン・可変パターンのいずれかを選択する。
+
+## 2. ID参照パターン
+
+```rust
+// Good: IDによる間接参照
+pub struct Order {
+    id: OrderId,
+    customer_id: CustomerId,  // IDのみ保持
+}
+
+// Bad: 直接参照
+pub struct Order {
+    id: OrderId,
+    customer: Customer,  // 他の集約を直接参照
+}
+```
+
+## 3. 完全コンストラクタ / ファクトリ
+
+`new` や関連関数でファクトリを定義し、フィールドをprivateに保つことで完全初期化を保証する。
+
+```rust
+pub struct Order {
+    id: OrderId,
+    items: Vec<OrderItem>,
+    status: OrderStatus,
+    created_at: DateTime<Utc>,
+}
+
+impl Order {
+    // ファクトリメソッド: 新規作成
+    pub fn create(id: OrderId, items: Vec<OrderItem>) -> Result<Order, DomainError> {
+        let order = Order {
+            id,
+            items,
+            status: OrderStatus::Draft,
+            created_at: Utc::now(),
+        };
+        order.validate()?;
+        Ok(order)
+    }
+
+    // 再構築用（リポジトリから復元時）
+    pub fn reconstruct(
+        id: OrderId,
+        items: Vec<OrderItem>,
+        status: OrderStatus,
+        created_at: DateTime<Utc>,
+    ) -> Order {
+        Order { id, items, status, created_at }
+    }
+}
+```
+
+## 4. 防御的コピー
+
+Rustの所有権システムにより、防御的コピーの必要性は大幅に低減される。参照を返す場合はライフタイムで安全性が保証される。
+
+```rust
+impl Order {
+    // スライス参照を返す（所有権は移動しない、変更不可）
+    pub fn items(&self) -> &[OrderItem] {
+        &self.items
+    }
+
+    // コピーが必要な場合は明示的にclone
+    pub fn items_owned(&self) -> Vec<OrderItem> {
+        self.items.clone()
+    }
+}
+```
+
+## 5. 不変条件の検証
+
+Rustでは `Result` 型でエラーを返すパターンが標準的。ファクトリメソッドで検証し、不正な状態のインスタンスが生成されないことを保証する。
+
+```rust
+#[derive(Debug)]
+pub enum OrderError {
+    EmptyItems,
+    InvalidQuantity,
+}
+
+pub struct Order {
+    id: OrderId,
+    items: Vec<OrderItem>,
+}
+
+impl Order {
+    pub fn create(id: OrderId, items: Vec<OrderItem>) -> Result<Order, OrderError> {
+        if items.is_empty() {
+            return Err(OrderError::EmptyItems);
+        }
+        if !items.iter().all(|item| item.quantity() > 0) {
+            return Err(OrderError::InvalidQuantity);
+        }
+        Ok(Order { id, items })
+    }
+
+    pub fn add_item(self, item: OrderItem) -> Result<Order, OrderError> {
+        let mut items = self.items;
+        items.push(item);
+        // 再度バリデーション（不変条件の維持）
+        Order::create(self.id, items)
+    }
+}
+```
+
+privateな `validate` メソッドで不変条件を集約する：
+
+```rust
+impl Order {
+    fn validate(&self) -> Result<(), OrderError> {
+        if self.items.is_empty() {
+            return Err(OrderError::EmptyItems);
+        }
+        if !self.items.iter().all(|item| item.quantity() > 0) {
+            return Err(OrderError::InvalidQuantity);
+        }
+        Ok(())
+    }
+}
+```
+
+Design by Contract（DbC）の例：
+
+```rust
+pub struct Car {
+    id: CarId,
+    tires: [Tire; 4],  // 型レベルで「4本」を保証
+    engine: Engine,
+}
+
+impl Car {
+    pub fn replace_tire(self, position: usize, new_tire: Tire) -> Result<Car, CarError> {
+        // 事前条件
+        if position >= 4 {
+            return Err(CarError::InvalidTirePosition);
+        }
+
+        let mut tires = self.tires;
+        tires[position] = new_tire;
+
+        Ok(Car { tires, ..self })
+        // 事後条件：配列サイズは型レベルで[Tire; 4]に固定されているため不要
+    }
+}
+```
+
+## 6. ドメインイベント
+
+```rust
+pub struct Order {
+    id: OrderId,
+    status: OrderStatus,
+    domain_events: Vec<DomainEvent>,
+    // ...other fields
+}
+
+impl Order {
+    pub fn confirm(self) -> Order {
+        let mut events = self.domain_events;
+        events.push(DomainEvent::OrderConfirmed {
+            order_id: self.id.clone(),
+            confirmed_at: Utc::now(),
+        });
+        Order {
+            status: OrderStatus::Confirmed,
+            domain_events: events,
+            ..self
+        }
+    }
+
+    pub fn domain_events(&self) -> &[DomainEvent] {
+        &self.domain_events
+    }
+
+    pub fn clear_events(self) -> Order {
+        Order {
+            domain_events: Vec::new(),
+            ..self
+        }
+    }
+}
+```
+
+## 7. 楽観的ロック
+
+```rust
+pub struct Order {
+    id: OrderId,
+    version: u64,  // 並行制御用（要件がある場合のみ）
+    // ...other fields
+}
+
+impl Order {
+    pub fn version(&self) -> u64 { self.version }
+
+    // リポジトリ側でバージョンチェック
+    // UPDATE orders SET ... WHERE id = $1 AND version = $2
+}
+```
+
+---
+
+## 集約ルート経由のアクセス
+
+```rust
+// Good: 集約ルート経由
+order.update_item_quantity(item_id, new_quantity);
+
+// Bad: 内部オブジェクトを直接操作
+if let Some(item) = order.items_mut().iter_mut().find(|i| i.id() == item_id) {
+    item.update_quantity(new_quantity);
+}
+```
+
+## Rust特有の設計パターン
+
+### 型レベルでの不変条件保証
+
+Rustでは型システムを活用して不変条件をコンパイル時に保証できる：
+
+```rust
+// 型で状態を表現（Typestate Pattern）
+pub struct DraftOrder { /* fields */ }
+pub struct ConfirmedOrder { /* fields */ }
+
+impl DraftOrder {
+    pub fn confirm(self) -> ConfirmedOrder {
+        ConfirmedOrder { /* ... */ }
+    }
+}
+
+// ConfirmedOrderにはconfirm()がない → 二重確認が型レベルで不可能
+```
+
+### newtype パターンによるID
+
+```rust
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct OrderId(String);
+
+impl OrderId {
+    pub fn new(value: impl Into<String>) -> Self {
+        OrderId(value.into())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct CustomerId(String);
+// OrderIdとCustomerIdは異なる型 → 取り違えがコンパイルエラー
+```

--- a/skills/aggregate-design/references/scala.md
+++ b/skills/aggregate-design/references/scala.md
@@ -1,0 +1,200 @@
+# 集約設計パターン - Scala
+
+## 目次
+
+1. [不変集約の実装](#1-不変集約の実装)
+2. [ID参照パターン](#2-id参照パターン)
+3. [完全コンストラクタ / ファクトリ](#3-完全コンストラクタ--ファクトリ)
+4. [防御的コピー](#4-防御的コピー)
+5. [不変条件の検証](#5-不変条件の検証)
+6. [ドメインイベント](#6-ドメインイベント)
+7. [楽観的ロック](#7-楽観的ロック)
+
+---
+
+## 1. 不変集約の実装
+
+case class + `copy()` パターンを使用する。Scalaではcase classがデフォルトで不変であり、`copy()` で変更フィールドのみを指定できる。
+
+```scala
+// Good: case class + copy() による不変な集約
+final case class Order private (
+  id: OrderId,
+  items: List[OrderItem],
+  status: OrderStatus
+) {
+  def addItem(item: OrderItem): Order =
+    copy(items = items :+ item)
+
+  def confirm(): Order =
+    copy(status = OrderStatus.Confirmed)
+}
+
+object Order {
+  def create(id: OrderId, items: List[OrderItem]): Order =
+    Order(id, items, OrderStatus.Draft)
+}
+```
+
+```scala
+// Bad: 可変な集約
+class Order(val id: OrderId) {
+  private var _items: ListBuffer[OrderItem] = ListBuffer.empty
+  def addItem(item: OrderItem): Unit = _items += item
+}
+```
+
+## 2. ID参照パターン
+
+```scala
+// Good: IDによる間接参照
+final case class Order(
+  id: OrderId,
+  customerId: CustomerId  // IDのみ保持
+)
+
+// Bad: 直接参照
+final case class Order(
+  id: OrderId,
+  customer: Customer  // 他の集約を直接参照
+)
+```
+
+## 3. 完全コンストラクタ / ファクトリ
+
+コンパニオンオブジェクトにファクトリメソッドを定義し、privateコンストラクタで完全初期化を保証する。
+
+```scala
+final case class Order private (
+  id: OrderId,
+  items: List[OrderItem],
+  status: OrderStatus,
+  createdAt: Instant
+)
+
+object Order {
+  // ファクトリメソッド: 新規作成
+  def create(id: OrderId, items: List[OrderItem]): Order =
+    Order(id, items, OrderStatus.Draft, Instant.now())
+
+  // 再構築用（リポジトリから復元時）
+  def reconstruct(
+    id: OrderId,
+    items: List[OrderItem],
+    status: OrderStatus,
+    createdAt: Instant
+  ): Order = Order(id, items, status, createdAt)
+}
+```
+
+## 4. 防御的コピー
+
+Scalaの不変コレクション（`List`, `Vector` 等）はデフォルトで不変のため、防御的コピーは通常不要。
+
+```scala
+// Scalaの不変コレクションは防御的コピー不要
+final case class Order(
+  id: OrderId,
+  items: List[OrderItem]  // Listはデフォルトで不変
+) {
+  // そのまま返しても安全
+  def getItems: List[OrderItem] = items
+}
+```
+
+Java連携等で可変コレクションを扱う場合は変換する：
+
+```scala
+import scala.jdk.CollectionConverters._
+
+// Java連携時は不変コレクションに変換
+def fromJava(javaItems: java.util.List[OrderItem]): Order =
+  Order(id, javaItems.asScala.toList)  // 不変Listに変換
+```
+
+## 5. 不変条件の検証
+
+`require` で事前条件・不変条件を検証する。`ensuring` で事後条件を表現する。
+
+```scala
+final case class Order private (
+  id: OrderId,
+  items: List[OrderItem],
+  status: OrderStatus
+) {
+  // 不変条件
+  require(items.nonEmpty, "注文には最低1つの商品が必要")
+  require(items.forall(_.quantity > 0), "数量は正の数")
+
+  def addItem(item: OrderItem): Order =
+    copy(items = items :+ item)
+    // copy()経由で新インスタンスが生成され、requireが再評価される
+}
+```
+
+Design by Contract（DbC）の完全な例：
+
+```scala
+final case class Car private (
+  id: CarId,
+  tires: List[Tire],
+  engine: Engine
+) {
+  // 不変条件（常に満たす）
+  require(tires.size == 4, "タイヤは4本必要")
+
+  def replaceTire(position: Int, newTire: Tire): Car = {
+    // 事前条件
+    require(position >= 0 && position < 4, "タイヤ位置は0-3")
+
+    copy(tires = tires.updated(position, newTire))
+  } ensuring { result =>
+    result.tires.size == 4  // 事後条件
+  }
+}
+```
+
+## 6. ドメインイベント
+
+```scala
+final case class Order private (
+  id: OrderId,
+  status: OrderStatus,
+  domainEvents: List[DomainEvent]
+  // ...other fields
+) {
+  def confirm(): Order =
+    copy(
+      status = OrderStatus.Confirmed,
+      domainEvents = domainEvents :+ OrderConfirmed(id, Instant.now())
+    )
+
+  def clearEvents(): Order =
+    copy(domainEvents = List.empty)
+}
+```
+
+## 7. 楽観的ロック
+
+```scala
+final case class Order private (
+  id: OrderId,
+  version: Long,  // 並行制御用（要件がある場合のみ）
+  // ...other fields
+)
+
+// リポジトリ側でバージョンチェック
+// UPDATE orders SET ... WHERE id = ? AND version = ?
+```
+
+---
+
+## 集約ルート経由のアクセス
+
+```scala
+// Good: 集約ルート経由
+order.updateItemQuantity(itemId, newQuantity)
+
+// Bad: 内部オブジェクトを直接操作
+order.items.find(_.id == itemId).map(_.updateQuantity(newQuantity))
+```

--- a/skills/aggregate-design/references/typescript.md
+++ b/skills/aggregate-design/references/typescript.md
@@ -1,0 +1,279 @@
+# 集約設計パターン - TypeScript
+
+## 目次
+
+1. [不変集約の実装](#1-不変集約の実装)
+2. [ID参照パターン](#2-id参照パターン)
+3. [完全コンストラクタ / ファクトリ](#3-完全コンストラクタ--ファクトリ)
+4. [防御的コピー](#4-防御的コピー)
+5. [不変条件の検証](#5-不変条件の検証)
+6. [ドメインイベント](#6-ドメインイベント)
+7. [楽観的ロック](#7-楽観的ロック)
+
+---
+
+## 1. 不変集約の実装
+
+Props型 + `...this.props` スプレッド構文パターンを使用する。
+フィールド追加時の修正漏れを防ぎ、更新意図が明確になる。
+
+```typescript
+// Good: Props型 + スプレッド構文による不変な集約
+type OrderProps = {
+  readonly id: OrderId;
+  readonly items: readonly OrderItem[];
+  readonly status: OrderStatus;
+};
+
+class Order {
+  private constructor(private readonly props: OrderProps) {}
+
+  static create(id: OrderId, items: OrderItem[]): Order {
+    return new Order({ id, items, status: OrderStatus.DRAFT });
+  }
+
+  addItem(item: OrderItem): Order {
+    return new Order({
+      ...this.props,
+      items: [...this.props.items, item],
+    });
+  }
+
+  confirm(): Order {
+    return new Order({
+      ...this.props,
+      status: OrderStatus.CONFIRMED,
+    });
+  }
+
+  get id(): OrderId { return this.props.id; }
+  get items(): readonly OrderItem[] { return this.props.items; }
+  get status(): OrderStatus { return this.props.status; }
+}
+```
+
+```typescript
+// Bad: フィールド全列挙（フィールド追加時に全メソッドの修正が必要）
+class Order {
+  addItem(item: OrderItem): Order {
+    return new Order(this.id, [...this.items, item], this.status);
+  }
+}
+```
+
+```typescript
+// Bad: 可変な集約
+class Order {
+  private items: OrderItem[] = [];
+  constructor(readonly id: OrderId) {}
+  addItem(item: OrderItem): void { this.items.push(item); }
+}
+```
+
+## 2. ID参照パターン
+
+他の集約とは直接参照ではなくIDで関連を持つ。
+
+```typescript
+// Good: IDによる間接参照
+class Order {
+  constructor(
+    readonly id: OrderId,
+    readonly customerId: CustomerId  // IDのみ保持
+  ) {}
+}
+
+// Bad: 直接参照
+class Order {
+  constructor(
+    readonly id: OrderId,
+    readonly customer: Customer  // 他の集約を直接参照
+  ) {}
+}
+```
+
+## 3. 完全コンストラクタ / ファクトリ
+
+基本コンストラクタですべての状態を初期化する。ファクトリメソッドは基本コンストラクタを利用する。
+
+```typescript
+class Order {
+  private constructor(
+    readonly id: OrderId,
+    readonly items: readonly OrderItem[],
+    readonly status: OrderStatus,
+    readonly createdAt: Date
+  ) {}
+
+  // ファクトリメソッドは基本コンストラクタを利用
+  static create(id: OrderId, items: OrderItem[]): Order {
+    return new Order(id, items, OrderStatus.DRAFT, new Date());
+  }
+}
+```
+
+Props型パターンと組み合わせる場合：
+
+```typescript
+type OrderProps = {
+  readonly id: OrderId;
+  readonly items: readonly OrderItem[];
+  readonly status: OrderStatus;
+  readonly createdAt: Date;
+};
+
+class Order {
+  private constructor(private readonly props: OrderProps) {
+    // 不変条件の検証（セクション5参照）
+  }
+
+  static create(id: OrderId, items: OrderItem[]): Order {
+    return new Order({
+      id,
+      items,
+      status: OrderStatus.DRAFT,
+      createdAt: new Date(),
+    });
+  }
+
+  // 再構築用（リポジトリから復元時）
+  static reconstruct(props: OrderProps): Order {
+    return new Order(props);
+  }
+}
+```
+
+## 4. 防御的コピー
+
+可変オブジェクトを保持する場合、外部に返す際はコピーを返すか不変オブジェクトに変換する。
+
+```typescript
+class Order {
+  private readonly _items: OrderItem[];
+
+  constructor(items: OrderItem[]) {
+    this._items = [...items];  // 入力をコピー
+  }
+
+  get items(): readonly OrderItem[] {
+    return [...this._items];  // コピーを返す
+  }
+}
+```
+
+Props型パターンでは `readonly` 修飾子により防御的コピーが不要になる場合が多い：
+
+```typescript
+type OrderProps = {
+  readonly id: OrderId;
+  readonly items: readonly OrderItem[];  // readonlyで保護
+};
+
+class Order {
+  private constructor(private readonly props: OrderProps) {}
+
+  get items(): readonly OrderItem[] {
+    return this.props.items;  // readonlyなのでそのまま返せる
+  }
+}
+```
+
+## 5. 不変条件の検証
+
+不変な集約ではコンストラクタで不変条件を検証する。すべての生成・更新はコンストラクタを経由するため、不正な状態が存在し得ない。
+
+```typescript
+type OrderProps = {
+  readonly id: OrderId;
+  readonly items: readonly OrderItem[];
+};
+
+class Order {
+  private constructor(private readonly props: OrderProps) {
+    // 不変条件：コンストラクタで一元的に検証
+    if (props.items.length === 0) {
+      throw new Error("注文には最低1つの商品が必要");
+    }
+    if (!props.items.every(item => item.quantity > 0)) {
+      throw new Error("数量は正の数");
+    }
+  }
+
+  addItem(item: OrderItem): Order {
+    // 新しいインスタンス生成時にコンストラクタで不変条件が検証される
+    return new Order({
+      ...this.props,
+      items: [...this.props.items, item],
+    });
+  }
+}
+```
+
+## 6. ドメインイベント
+
+集約の状態変更時にドメインイベントを発行する。Props型パターンでイベントも不変に管理する。
+
+```typescript
+type OrderProps = {
+  readonly id: OrderId;
+  readonly status: OrderStatus;
+  readonly domainEvents: readonly DomainEvent[];
+  // ...other fields
+};
+
+class Order {
+  private constructor(private readonly props: OrderProps) {}
+
+  get domainEvents(): readonly DomainEvent[] {
+    return this.props.domainEvents;
+  }
+
+  confirm(): Order {
+    return new Order({
+      ...this.props,
+      status: OrderStatus.CONFIRMED,
+      domainEvents: [
+        ...this.props.domainEvents,
+        new OrderConfirmed(this.props.id, new Date()),
+      ],
+    });
+  }
+
+  clearEvents(): Order {
+    return new Order({ ...this.props, domainEvents: [] });
+  }
+}
+```
+
+## 7. 楽観的ロック
+
+並行更新の衝突検出が必要な場合にのみバージョン番号を持たせる。
+
+```typescript
+type OrderProps = {
+  readonly id: OrderId;
+  readonly version: number;  // 並行制御用
+  // ...other fields
+};
+
+class Order {
+  private constructor(private readonly props: OrderProps) {}
+
+  get version(): number { return this.props.version; }
+
+  // リポジトリ側でバージョンチェック
+  // UPDATE orders SET ... WHERE id = ? AND version = ?
+}
+```
+
+---
+
+## 集約ルート経由のアクセス
+
+```typescript
+// Good: 集約ルート経由
+order.updateItemQuantity(itemId, newQuantity);
+
+// Bad: 内部オブジェクトを直接操作
+order.items.find(item => item.id === itemId)?.updateQuantity(newQuantity);
+```


### PR DESCRIPTION
…r aggregate design patterns

- Introduced new language-specific reference documents:
  - `rust.md`: Includes immutable aggregate creation, defensive copying, domain events, and optimistic locking.
  - `scala.md`: Case class-focused immutable patterns, `copy()` usage, and DbC examples.
  - `typescript.md`: Props + spread syntax for immutability, defensive copying, and event handling.
- Enhanced cross-language learning and best practices for Domain-Driven Design aggregate patterns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only additions with no runtime/codepath changes. Review risk is limited to accuracy/consistency of guidance and examples.
> 
> **Overview**
> Adds new reference documentation under `skills/aggregate-design/references/` for **Rust**, **Scala**, and **TypeScript**.
> 
> Each doc provides language-specific examples for aggregate design patterns (immutable updates, ID-only references, factories/reconstruction, invariant validation, defensive copying, domain events, and optional optimistic locking) to align guidance across languages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9bb520e5c5d5442d0013972731ce2fc7751287b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->